### PR TITLE
ci: Update release.yml to include pre-release option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,17 @@ jobs:
         with:
           name: macos-arm-dist
           path: dist/
+      - name: Create GitHub Pre-release
+        if: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'dev') }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --generate-notes --prerelease
       - name: Create GitHub Release
+        if: ${{ !(contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'dev')) }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-


### PR DESCRIPTION
Add the option to add automatically make the version pre-release by adding "alpha", "beta", or "dev" to the tag pushed to the repository.