### PR TITLE
ci: Change Linux runner image to Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-linux:
     name: Build for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
In order to increase compatibility, we change the Linux runner image to `ubuntu-22.04` so that an earlier Python version is pulled. That way, the required version of glibc is lower and the AppImage can be supported on older systems.

Fixes https://github.com/icarito/gtk-llm-chat/issues/28