### PR TITLE
Fix appimage for older Linux systems (fixes #28)

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -12,11 +12,12 @@ WINDOWS_ICON=windows/org.fuentelibre.gtk_llm_Chat.ico
 NSIS=windows/build.nsi
 
 # macOS-specific arguments
-# MACOS_ICON=macos/org.example.HelloWorldGTK.icns
+MACOS_ICON=macos/org.fuentelibre.gtk_llm_Chat.icns
 
 # Linux-specific arguments
 LINUX_ICON=linux/org.fuentelibre.gtk_llm_Chat.png
 # APPDATA=linux/org.fuentelibre.gtk_llm_Chat.appdata.xml
+LINUX_APPIMAGETOOL=linux/appimagetool-wrap.sh
 
 # Linux desktop file arguments
 Type=Application

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-linux:
     name: Build for Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,18 @@ jobs:
             linux-headers-$(uname -r) libcurl4-nss-dev libxcursor-dev \
             libxkbcommon-dev libxml2-utils libxrandr-dev libxi-dev \
             libwayland-dev libxinerama-dev \
-            gperf libappstream-dev libxmlb-dev libxdamage-dev gettext valac
+            gperf libappstream-dev libxmlb-dev libxdamage-dev gettext valac \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            gir1.2-gtk-3.0 \
+            gir1.2-ayatanaappindicator3-0.1 \
+            libglib2.0-0 \
+            libgirepository-1.0-1 \
+            libdbus-1-dev \
+            libdbus-glib-1-dev \
+            gir1.2-dbusmenu-glib-0.4 \
+            gir1.2-dbusmenu-gtk3-0.4 \
+            gir1.2-glib-2.0
 
           sudo pip install --upgrade pip meson
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,42 +9,113 @@ jobs:
   build-linux:
     name: Build for Linux
     runs-on: ubuntu-22.04
+#    env:
+#      VULKAN_SDK: ${{ github.workspace }}/1.4.309.0/x86_64
+#      VK_LAYER_PATH: ${{ github.workspace }}/1.4.309.0/x86_64/share/vulkan/explicit_layer.d
+#      VK_ADD_LAYER_PATH: ${{ github.workspace }}/1.4.309.0/x86_64/share/vulkan/explicit_layer.d
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install dependencies
+
+      - name: Install system dependencies
         run: |
-          sudo apt-mark hold firefox* linux-headers* linux-image* grub* > /dev/null
-          sudo apt update
-          sudo apt upgrade
-          sudo apt install desktop-file-utils
-          sudo apt-get install -y build-essential ninja-build libgtk-4-dev \
-          sassc pkg-config git cmake appstream fuse libfuse2 zsync curl python3-pip libglib2.0-dev libchafa-dev
-          wget http://ftp.gnome.org/pub/gnome/sources/pango/1.56/pango-1.56.1.tar.xz
-          tar -xf pango-1.56.1.tar.xz && cd pango-1.56.1 && ./configure && make && sudo make install
-          wget https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.15.0.tar.gz
-          tar -xzf fontconfig-2.15.0.tar.gz && cd fontconfig-2.15.0 && ./configure && make && sudo make install
-          sudo ./linux/bootstrap.sh
-      - name: Install Meson
+          sudo add-apt-repository -y ppa:kubuntu-ppa/backports-extra
+          sudo apt-get update
+          sudo apt-get install -y build-essential ninja-build git \
+            libxft-dev libepoxy-dev libgles2-mesa-dev libegl1-mesa-dev \
+            libpolkit-agent-1-dev libpolkit-gobject-1-dev libunwind-dev \
+            libx11-dev libxext-dev libdrm-dev libcups2-dev libsass-dev \
+            linux-headers-$(uname -r) libcurl4-nss-dev libxcursor-dev \
+            libxkbcommon-dev libxml2-utils libxrandr-dev libxi-dev \
+            libwayland-dev libxinerama-dev \
+            gperf libappstream-dev libxmlb-dev libxdamage-dev gettext valac
+
+          sudo pip install --upgrade pip meson
+
+# Couldn't get this to work:
+#      - name: Instalar Vulkan SDK (para glslc)
+#        run: |
+#          wget -qO- https://sdk.lunarg.com/sdk/download/1.4.309.0/linux/vulkansdk-linux-x86_64-1.4.309.0.tar.xz | tar xJ
+#          export VULKAN_SDK=$(pwd)/1.4.309.0/x86_64
+#          export PATH=$VULKAN_SDK/bin:$PATH
+#          echo "PATH actualizado: $PATH"
+#          glslc --version
+#          echo "LD_LIBRARY_PATH=${{ github.workspace }}/1.4.309.0/x86_64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+#          echo $VULKAN_SDK/bin >> $GITHUB_PATH
+
+      - name: Compila Gtk and friends
         run: |
-          python3 -m pip install --upgrade meson
-      - name: Build GTK4 from source
-        run: |
-          git clone https://gitlab.gnome.org/GNOME/gtk.git --depth=1
-          cd gtk
-          meson setup build -Dbuildtype=release -Dprefix=/opt/gtk
-          ninja -C build
-          sudo ninja -C build install
-      - name: Build and install libadwaita
-        run: |
-          git clone https://gitlab.gnome.org/GNOME/libadwaita.git
-          cd libadwaita
-          git checkout 1.3.0
-          meson setup _build -Dexamples=false -Dtests=false
-          meson compile -C _build
-          sudo meson install -C _build
+          echo "Compiling gobject-introspection into /usr"
+          echo "Using PKG_CONFIG_PATH: $PKG_CONFIG_PATH" # Debería encontrar tu glib-2.0.pc
+          GOBJECT_INTROSPECTION_VERSION="1.80.0" # Elige una versión compatible con tu GLib y GTK4
+                                               # GLib 2.82 podría necesitar una versión reciente.
+                                               # 1.80.0 es una versión relativamente nueva. Revisa compatibilidades.
+          wget "https://download.gnome.org/sources/gobject-introspection/${GOBJECT_INTROSPECTION_VERSION%.*}/gobject-introspection-${GOBJECT_INTROSPECTION_VERSION}.tar.xz"
+          tar -xf "gobject-introspection-${GOBJECT_INTROSPECTION_VERSION}.tar.xz"
+          cd "gobject-introspection-${GOBJECT_INTROSPECTION_VERSION}"
+          # Configura Meson para instalar en /usr.
+          # Necesita encontrar Python3 y tu GLib.
+          meson setup _build --prefix=/usr \
+            --buildtype=release \
+            -Ddoctool=disabled # Si no necesitas las herramientas de documentación
+          ninja -C _build
+          sudo ninja -C _build install # Instala en /usr
           cd ..
-      - name: Set up environment
+          git clone https://gitlab.gnome.org/GNOME/glib.git --branch glib-2-82 --depth 1
+          cd glib
+          meson setup _build --prefix=/usr \
+            -Dintrospection=enabled \
+            --buildtype=release -Ddocumentation=false -Dtests=false -Dman=false
+          ninja -C _build
+          sudo ninja -C _build install
+          cd ..
+          git clone https://gitlab.gnome.org/GNOME/pango.git --branch 1.52.2 --depth 1
+          cd pango
+          meson setup _build --prefix=/usr \
+            --buildtype=release -Dintrospection=enabled \
+            -Dfontconfig=enabled -Dfreetype=enabled
+          ninja -C _build
+          sudo ninja -C _build install
+          cd ..
+          wget "https://download.gnome.org/sources/graphene/1.8/graphene-1.8.6.tar.xz"
+          tar -xf "graphene-1.8.6.tar.xz"
+          cd "graphene-1.8.6"
+          meson setup _build --prefix=/usr \
+            --buildtype=release \
+            -Dtests=false
+          ninja -C _build
+          sudo ninja -C _build install
+          cd ..
+          git clone https://gitlab.freedesktop.org/fontconfig/fontconfig.git --branch 2.15.0 --depth 1
+          cd fontconfig
+          meson setup _build --prefix=/usr \
+            --buildtype=release -Ddoc=disabled -Dtests=disabled -Dtools=disabled
+          ninja -C _build
+          sudo ninja -C _build install
+          cd ..
+          git clone https://gitlab.gnome.org/GNOME/gtk.git --branch gtk-4-18 --depth 1
+          cd gtk
+          meson setup _build --prefix=/usr \
+            --buildtype=release \
+            -Dmedia-gstreamer=disabled \
+            -Dbuild-tests=false \
+            -Dbuild-examples=false \
+            -Dbuild-demos=false \
+            -Dintrospection=enabled \
+            -Dvulkan=disabled
+          ninja -C _build
+          sudo ninja -C _build install
+          cd ..
+          git clone https://gitlab.gnome.org/GNOME/libadwaita.git --branch libadwaita-1-7 --depth 1
+          cd libadwaita
+          meson setup _build --prefix=/usr \
+            -Dintrospection=enabled \
+            --buildtype=release
+          ninja -C _build
+          sudo ninja -C _build install
+
+      - name: Set environment for build
         run: |
           cp .env.ci .env
       - name: Build package
@@ -97,6 +168,7 @@ jobs:
           ./macos/bootstrap.sh
           python3 -m pip install pycairo
           python3 -m pip install PyGObject
+
       - name: Set up environment
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,35 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-mark hold firefox* linux-headers* linux-image* grub* > /dev/null
-          sudo apt install -y software-properties-common
-          sudo add-apt-repository ppa:xtradeb/apps -y
           sudo apt update
           sudo apt upgrade
           sudo apt install desktop-file-utils
+          sudo apt-get install -y build-essential ninja-build libgtk-4-dev \
+          sassc pkg-config git cmake appstream fuse libfuse2 zsync curl python3-pip libglib2.0-dev libchafa-dev
+          wget http://ftp.gnome.org/pub/gnome/sources/pango/1.56/pango-1.56.1.tar.xz
+          tar -xf pango-1.56.1.tar.xz && cd pango-1.56.1 && ./configure && make && sudo make install
+          wget https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.15.0.tar.gz
+          tar -xzf fontconfig-2.15.0.tar.gz && cd fontconfig-2.15.0 && ./configure && make && sudo make install
           sudo ./linux/bootstrap.sh
+      - name: Install Meson
+        run: |
+          python3 -m pip install --upgrade meson
+      - name: Build GTK4 from source
+        run: |
+          git clone https://gitlab.gnome.org/GNOME/gtk.git --depth=1
+          cd gtk
+          meson setup build -Dbuildtype=release -Dprefix=/opt/gtk
+          ninja -C build
+          sudo ninja -C build install
+      - name: Build and install libadwaita
+        run: |
+          git clone https://gitlab.gnome.org/GNOME/libadwaita.git
+          cd libadwaita
+          git checkout 1.3.0
+          meson setup _build -Dexamples=false -Dtests=false
+          meson compile -C _build
+          sudo meson install -C _build
+          cd ..
       - name: Set up environment
         run: |
           cp .env.ci .env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
+          sudo apt-mark hold firefox* linux-headers* linux-image* grub* > /dev/null
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository ppa:xtradeb/apps -y
           sudo apt update
-          sudo apt-mark hold firefox* linux-headers* linux-image* grub*
           sudo apt upgrade
           sudo apt install desktop-file-utils
           sudo ./linux/bootstrap.sh

--- a/build.spec
+++ b/build.spec
@@ -22,6 +22,8 @@ typelibs = []
 for name in ('Adw-1.typelib',
         'Atk-1.0.typelib',
         'AyatanaAppIndicator3-0.1.typelib',
+	'DBus-1.0.typelib',
+	'DBusGLib-1.0.typelib',
         'GLib-2.0.typelib',
         'GModule-2.0.typelib',
         'GObject-2.0.typelib',
@@ -90,8 +92,10 @@ a = Analysis(
         'gtk_llm_chat.widgets',
         'gtk_llm_chat.markdownview',
         'gtk_llm_chat.llm_client',
+        'gtk_llm_chat.tray_applet',
         'gtk_llm_chat._version',
         'locale',
+	'gi.repository.DBus',
     ]
 )
 

--- a/build.spec
+++ b/build.spec
@@ -3,6 +3,44 @@
 from argparse import ArgumentParser
 from platform import system
 from PyInstaller.building.datastruct import TOC
+import glob
+
+libdir = '/usr/lib/x86_64-linux-gnu'
+patterns = [
+  'libadwaita-1.so*',
+  'libgtk-4.so*',
+  'libgdk-4.so*',
+  'libpangocairo-1.0.so*',
+]
+binaries = []
+for pat in patterns:
+    for src in glob.glob(os.path.join(libdir, pat)):
+        binaries.append((src, '.'))
+
+typedir = '/usr/lib/x86_64-linux-gnu/girepository-1.0'
+typelibs = []
+for name in ('Adw-1.typelib',
+        'Atk-1.0.typelib',
+        'AyatanaAppIndicator3-0.1.typelib',
+        'GLib-2.0.typelib',
+        'GModule-2.0.typelib',
+        'GObject-2.0.typelib',
+        'Gdk-3.0.typelib',
+        'Gdk-4.0.typelib',
+        'GdkPixbuf-2.0.typelib',
+        'Gio-2.0.typelib'
+        'Graphene-1.0.typelib',
+        'Gsk-4.0.typelib',
+        'Gtk-3.0.typelib',
+        'Gtk-4.0.typelib',
+        'HarfBuzz-0.0.typelib',
+        'Pango-1.0.typelib',
+        'PangoCairo-1.0.typelib',
+        'cairo-1.0.typelib',
+        'freetype2-2.0.typelib',
+        'xlib-2.0.typelib'):
+    for src in glob.glob(os.path.join(typedir, name)):
+        typelibs.append((src, 'gi_typelibs'))
 
 parser = ArgumentParser()
 parser.add_argument("--binary", action="store_true")
@@ -11,7 +49,7 @@ options = parser.parse_args()
 a = Analysis(
     ['gtk_llm_chat/main.py'],
     pathex=['gtk_llm_chat'],
-    binaries=[],
+    binaries=binaries,
     hookspath=['hooks'],
     hooksconfig={
         'gi': {
@@ -30,7 +68,7 @@ a = Analysis(
         ('po', 'po'),
         ('gtk_llm_chat/hicolor', 'gtk_llm_chat/hicolor'),
         ('windows/*.png', 'windows')
-    ],
+    ] + typelibs,
     hiddenimports=[
         'gettext',
         'llm',

--- a/gtk_llm_chat/chat_application.py
+++ b/gtk_llm_chat/chat_application.py
@@ -246,39 +246,32 @@ class LLMChatApplication(Adw.Application):
         """Crea una nueva ventana con la configuración dada."""
         debug_print(f"Creando nueva ventana con configuración: {config}")
         
-        try:
-            from chat_window import LLMChatWindow
-            chat_history = ChatHistory()
-            
-            # Crear la nueva ventana con la configuración
-            window = LLMChatWindow(application=self, config=config, chat_history=chat_history)
-            window.set_icon_name("org.fuentelibre.gtk_llm_Chat")
-            
-            # Configurar el manejador de eventos de teclado
-            key_controller = Gtk.EventControllerKey()
-            key_controller.connect("key-pressed", self._on_key_pressed)
-            window.add_controller(key_controller)
-            
-            # Registrar la ventana por CID si existe
-            if 'cid' in config and config['cid']:
-                cid = config['cid']
-                self._window_by_cid[cid] = window
-                debug_print(f"Ventana registrada para CID: {cid}")
-                
-                # Conectar señal de cierre para eliminar del registro
-                # Ya no es necesario conectar un manejador de cierre aquí, la lógica está en LLMChatWindow
-
-            
-            # Presentar la ventana
-            window.present()
-            
-            return window
-        except Exception as e:
-            debug_print(f"Error al crear nueva ventana: {e}")
-            
-            # En caso de error, activar la ventana normalmente
-            self.activate()
-            return None
+        #try:
+        from chat_window import LLMChatWindow
+        chat_history = ChatHistory()
+        
+        # Crear la nueva ventana con la configuración
+        window = LLMChatWindow(application=self, config=config, chat_history=chat_history)
+        window.set_icon_name("org.fuentelibre.gtk_llm_Chat")
+        
+        # Configurar el manejador de eventos de teclado
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect("key-pressed", self._on_key_pressed)
+        window.add_controller(key_controller)
+        
+        # Registrar la ventana por CID si existe
+        if 'cid' in config and config['cid']:
+            cid = config['cid']
+            self._window_by_cid[cid] = window
+            debug_print(f"Ventana registrada para CID: {cid}")
+        
+        # Presentar la ventana
+        window.present()
+        
+        return window
+        #except Exception as e:
+        #    debug_print(f"Error al crear nueva ventana: {e}")
+        #    return None
 
     def _on_key_pressed(self, controller, keyval, keycode, state):
         """Maneja eventos de teclado a nivel de aplicación."""

--- a/gtk_llm_chat/chat_window.py
+++ b/gtk_llm_chat/chat_window.py
@@ -341,7 +341,7 @@ class LLMChatWindow(Adw.ApplicationWindow):
             /* Estilos opcionales para el sidebar */
             /* .sidebar-title { ... } */
         """
-        css_provider.load_from_data(data.encode('UTF-8'), -1) # Usar -1
+        css_provider.load_from_data(data, -1) # Usar -1
 
         Gtk.StyleContext.add_provider_for_display(
             Gdk.Display.get_default(),

--- a/gtk_llm_chat/platform_utils.py
+++ b/gtk_llm_chat/platform_utils.py
@@ -25,23 +25,23 @@ def launch_tray_applet(config):
     """
     Lanza el applet de bandeja
     """
-    try:
-        from tray_applet import main
-        main()
-    except Exception as e:
-        if is_frozen():
-            # Relanzar el propio ejecutable con --applet
-            args = [sys.executable, "--applet"]
-            print(f"[platform_utils] Error lanzando applet (frozen): {e}")
-            # subprocess.Popen(args)
-        else:
-            # Ejecutar tray_applet.py con el intérprete
-            applet_path = os.path.join(os.path.dirname(__file__), 'tray_applet.py')
-            args = [sys.executable, applet_path]
-            if config.get('cid'):
-                args += ['--cid', config['cid']]
-            print(f"[platform_utils] Lanzando applet (no frozen): {args}")
-            subprocess.Popen(args)
+    #try:
+    from tray_applet import main
+    main()
+    #except Exception as e:
+    #    if is_frozen():
+    #        # Relanzar el propio ejecutable con --applet
+    #        args = [sys.executable, "--applet"]
+    #        print(f"[platform_utils] Error lanzando applet (frozen): {e}")
+    #        # subprocess.Popen(args)
+    #    else:
+    #        # Ejecutar tray_applet.py con el intérprete
+    #        applet_path = os.path.join(os.path.dirname(__file__), 'tray_applet.py')
+    #        args = [sys.executable, applet_path]
+    #        if config.get('cid'):
+    #            args += ['--cid', config['cid']]
+    #        print(f"[platform_utils] Lanzando applet (no frozen): {args}")
+    #        subprocess.Popen(args)
 
 def send_ipc_open_conversation(cid):
     """

--- a/linux/appimagetool-wrap.sh
+++ b/linux/appimagetool-wrap.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# appimagetool-wrap.sh
+# Envuelto para limpiar libssl interno y generar AppRun antes de invocar al real appimagetool
+
+# 1) rutas
+APPDIR="/home/runner/work/gtk-llm-chat/gtk-llm-chat/dist"
+REAL_TOOL="/home/runner/work/gtk-llm-chat/gtk-llm-chat/venv/lib/python3.10/site-packages/pydeployment/linux/appimagetool/appimagetool-x86_64.AppImage"   # o donde esté instalado tu appimagetool
+
+# 2) eliminar OpenSSL interno de PyInstaller
+rm -f "$APPDIR"/_internal/libssl.so*  "$APPDIR"/_internal/libcrypto.so*
+
+# 3) escribir AppRun que prioriza libs del sistema
+cat > "$APPDIR"/AppRun << 'EOF'
+#!/bin/bash
+
+# Obtener la ruta absoluta al directorio donde se está ejecutando AppRun
+# Esto es crucial para que las rutas internas funcionen correctamente
+APPDIR=$(dirname "$(readlink -f "$0")")
+
+# Configurar LD_LIBRARY_PATH para que encuentre las bibliotecas .so empaquetadas
+# (Es probable que ya tengas una línea similar, PyInstaller a menudo la gestiona)
+export LD_LIBRARY_PATH="${APPDIR}/_internal:${LD_LIBRARY_PATH}" # Ajusta si tus .so están en otro subdirectorio de _internal
+
+# >>> AÑADE O MODIFICA ESTA LÍNEA CRUCIAL <<<
+# Configurar GI_TYPELIB_PATH para apuntar a los archivos .typelib empaquetados
+export GI_TYPELIB_PATH="${APPDIR}/_internal/gi_typelibs:${GI_TYPELIB_PATH}"
+
+# Otras variables de entorno importantes que podrías necesitar:
+# Para que encuentre esquemas GSettings, .desktop files, iconos, etc.
+# Tu .desktop está en APPDIR/usr/share/applications/
+# Tus iconos de app están en APPDIR/_internal/gtk_llm_chat/hicolor/
+export XDG_DATA_DIRS="${APPDIR}/usr/share:${APPDIR}/_internal/share:${APPDIR}/_internal/gtk_llm_chat:${XDG_DATA_DIRS}"
+
+# Si empaquetas esquemas GSettings (recomendado, como en la versión de Ubuntu 24):
+# export GSETTINGS_SCHEMA_DIR="${APPDIR}/_internal/share/glib-2.0/schemas"
+
+# Para traducciones (si están en APPDIR/_internal/po y tu dominio es "gtk-llm-chat")
+export TEXTDOMAINDIR="${APPDIR}/_internal/po"
+export TEXTDOMAIN="gtk-llm-chat" # Reemplaza con tu text domain real
+
+# Ejecutar el binario principal de tu aplicación (el que creó PyInstaller)
+# Asegúrate de que el nombre y la ruta del ejecutable sean correctos.
+# Si PyInstaller creó "chat_application" y está en _internal:
+# ... (definición de APPDIR y exportaciones de LD_LIBRARY_PATH) ...
+
+export GI_TYPELIB_PATH="${APPDIR}/_internal/gi_typelibs:${GI_TYPELIB_PATH}"
+export XDG_DATA_DIRS="${APPDIR}/usr/share:${APPDIR}/_internal/share:${APPDIR}/_internal/gtk_llm_chat:${XDG_DATA_DIRS}"
+# ... (otras exportaciones) ...
+
+# --- Debugging lines ---
+echo "--- AppRun Debug ---" >&2
+echo "APPDIR is: ${APPDIR}" >&2
+echo "GI_TYPELIB_PATH is: ${GI_TYPELIB_PATH}" >&2
+echo "Contents of GI_TYPELIB_PATH target:" >&2
+ls -l "${APPDIR}/_internal/gi_typelibs/" >&2
+echo "Python path:" >&2
+"${APPDIR}/gtk-llm-chat" -c "import sys; print(sys.path)" >&2 # Asumiendo que gtk-llm-chat es el ejecutable de Python
+echo "--- End AppRun Debug ---" >&2
+# --- End Debugging lines ---
+
+exec "${APPDIR}/gtk-llm-chat" "$@"
+EOF
+chmod +x "$APPDIR"/AppRun
+
+# 4) invoca al appimagetool “real”
+exec "$REAL_TOOL" "$@"
+

--- a/linux/bootstrap.sh
+++ b/linux/bootstrap.sh
@@ -1,2 +1,2 @@
-apt install libgtk-4-1 libgtk-4-dev libadwaita-1-0 gcc libcairo2-dev pkg-config python3-dev libgirepository1.0-dev libgirepository-1.0-1 gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-ayatanaappindicator3-0.1 libcairo-gobject2 libcairo2-dev libssl-dev
+apt install libgtk-4-1 libgtk-4-dev libadwaita-1-0 gcc libcairo2-dev pkg-config python3-dev libgirepository1.0-dev libgirepository-1.0-1 gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-ayatanaappindicator3-0.1 libcairo-gobject2 libcairo2-dev libssl-dev libayatana-appindicator3-1
 echo VERSION=\"$(git describe --tags --exact-match)\"  >> .env.ci

--- a/linux/bootstrap.sh
+++ b/linux/bootstrap.sh
@@ -1,2 +1,1 @@
-apt install libgtk-4-1 libgtk-4-dev libadwaita-1-0 gcc libcairo2-dev pkg-config python3-dev libgirepository1.0-dev libgirepository-1.0-1 gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-ayatanaappindicator3-0.1 libcairo-gobject2 libcairo2-dev libssl-dev libayatana-appindicator3-1
 echo VERSION=\"$(git describe --tags --exact-match)\"  >> .env.ci

--- a/linux/bootstrap.sh
+++ b/linux/bootstrap.sh
@@ -1,2 +1,2 @@
-apt install libgtk-4-1 libgtk-4-dev libadwaita-1-0 gcc libcairo2-dev pkg-config python3-dev libgirepository-2.0-0 libgirepository-2.0-dev gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-girepository-3.0 gir1.2-girepository-3.0-dev gir1.2-ayatanaappindicator3-0.1 libcairo-gobject2 libcairo2-dev libssl-dev
+apt install libgtk-4-1 libgtk-4-dev libadwaita-1-0 gcc libcairo2-dev pkg-config python3-dev libgirepository1.0-dev libgirepository-1.0-1 gir1.2-gtk-4.0 gir1.2-adw-1 gir1.2-ayatanaappindicator3-0.1 libcairo-gobject2 libcairo2-dev libssl-dev
 echo VERSION=\"$(git describe --tags --exact-match)\"  >> .env.ci

--- a/macos/bootstrap.sh
+++ b/macos/bootstrap.sh
@@ -1,1 +1,2 @@
 brew install pygobject3 gtk4 adwaita-icon-theme libadwaita
+python3 -m pip install --no-binary :all: --force-reinstall Pillow -C harfbuzz=disable -C freetype=disable --no-cache-dir


### PR DESCRIPTION
With the intention of fixing #28 i dived deep into the depths of ancient systems and managed to build an AppImage from Ubuntu 22.04 with recent Adwaita and all deps.

I did not manage to add libvulkan support for visual effects, but I can live with that!

Playing with build pipelines pointed me in the direction of fixing #21 too!
It's starting to look consistent but it's a lot of effort to mix toolkits like this.

Eventually perhaps we'll just loose the applet.