### PR TITLE
Try2 single tray instance (fixes #39)

### DIFF
--- a/gtk_llm_chat/main.py
+++ b/gtk_llm_chat/main.py
@@ -4,7 +4,7 @@ Gtk LLM Chat - A frontend for `llm`
 import argparse
 import sys
 import time
-from platform_utils import launch_tray_applet
+from platform_utils import launch_tray_applet, fork_or_spawn_applet
 
 # Benchmark
 benchmark_startup = '--benchmark-startup' in sys.argv
@@ -51,6 +51,8 @@ def main(argv=None):
     if config.get('applet'):
         launch_tray_applet(config)
         return 0
+    else:
+        fork_or_spawn_applet(config)
 
     # Lanzar la aplicación principal
     from chat_application import LLMChatApplication

--- a/gtk_llm_chat/platform_utils.py
+++ b/gtk_llm_chat/platform_utils.py
@@ -55,10 +55,8 @@ def spawn_tray_applet(config):
         # subprocess.Popen(args)
     else:
         # Ejecutar tray_applet.py con el intérprete
-        applet_path = os.path.join(os.path.dirname(__file__), 'tray_applet.py')
-        args = [sys.executable, applet_path]
-        if config.get('cid'):
-            args += ['--cid', config['cid']]
+        applet_path = os.path.join(os.path.dirname(__file__), 'main.py')
+        args = [sys.executable, applet_path, '--applet']
         print(f"[platform_utils] Lanzando applet (no frozen): {args}")
         subprocess.Popen(args)
 

--- a/gtk_llm_chat/platform_utils.py
+++ b/gtk_llm_chat/platform_utils.py
@@ -4,9 +4,24 @@ platform_utils.py - utilidades multiplataforma para gtk-llm-chat
 import sys
 import subprocess
 import os
+import tempfile
+from single_instance import SingleInstance
 
 PLATFORM = sys.platform
 
+def ensure_single_instance(lockfile=None):
+    """
+    Asegura que solo haya una instancia de la aplicación en ejecución.
+    """
+    if not lockfile:
+        lockdir = tempfile.gettempdir()
+        lockfile = os.path.join(lockdir, 'gtk_llm_applet.lock')
+    try:
+        single_instance = SingleInstance(lockfile)
+        return single_instance
+    except RuntimeError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
 def is_linux():
     return PLATFORM.startswith('linux')
@@ -25,6 +40,7 @@ def launch_tray_applet(config):
     """
     Lanza el applet de bandeja
     """
+    ensure_single_instance()
     try:
         from gtk_llm_chat.tray_applet import main
         main()

--- a/gtk_llm_chat/platform_utils.py
+++ b/gtk_llm_chat/platform_utils.py
@@ -58,7 +58,7 @@ def spawn_tray_applet(config):
         applet_path = os.path.join(os.path.dirname(__file__), 'main.py')
         args = [sys.executable, applet_path, '--applet']
         print(f"[platform_utils] Lanzando applet (no frozen): {args}")
-        subprocess.Popen(args)
+    subprocess.Popen(args)
 
 def send_ipc_open_conversation(cid):
     """

--- a/gtk_llm_chat/single_instance.py
+++ b/gtk_llm_chat/single_instance.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import atexit
+import platform
+
+if os.name == 'nt':
+    import msvcrt
+else:
+    import fcntl
+
+class SingleInstance:
+    def __init__(self, lockfile):
+        self.lockfile = os.path.abspath(lockfile)
+        self.fp = None
+
+        try:
+            self.fp = open(self.lockfile, 'w+')
+
+            if os.name == 'nt':
+                # Windows: intenta bloquear el archivo
+                try:
+                    msvcrt.locking(self.fp.fileno(), msvcrt.LK_NBLCK, 1)
+                except OSError:
+                    raise RuntimeError("Otra instancia ya se está ejecutando.")
+            else:
+                # Unix: intenta obtener un bloqueo exclusivo
+                try:
+                    fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError:
+                    raise RuntimeError("Otra instancia ya se está ejecutando.")
+
+            # Guarda el PID en el archivo para fines informativos
+            self.fp.write(str(os.getpid()))
+            self.fp.flush()
+
+            # Registra cleanup
+            atexit.register(self.cleanup)
+
+        except Exception:
+            if self.fp:
+                self.fp.close()
+            raise
+
+    def cleanup(self):
+        try:
+            if self.fp:
+                self.fp.close()
+            if os.path.exists(self.lockfile):
+                os.remove(self.lockfile)
+        except Exception:
+            pass  # Ignorar errores al salir
+
+


### PR DESCRIPTION
This unifies the behaviour of tray applets.

Upon launching a conversation, the applet starts, but only a single instance.

Combines a single instance (file) lock implementation and adds the logic for always attepmting to launch the applet.

:thinking: 

Should add "--no-applet" option? Or start keeping track of our own configuration probably.